### PR TITLE
fix: routes not being considered in the correct order

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ const getHandler = (url) => {
   
   const routes = Object.keys(mapping);
   const dynamicRoutes = routes.filter(route => route.includes('[') && route.includes(']'));
+  dynamicRoutes.sort((a, b) => b.length - a.length) // Most specific routes take precedence
 
   const { route, routeParams } = getDynamicRounte(dynamicRoutes, url);
   


### PR DESCRIPTION
**Expected**

If you have the following routes defined:
`/user/[id]`
`/user/[id]/locations`

Then a request to `/user/[id]/locations` will resolve to that, more specific, route.

**Actual**

A request to `/user/[id]/locations` resolves to `/user/[id]` as it comes across this one first.

**Proposed change**

This PR sorts the dynamic routes to have the longest routes first, which will ensure that, where routes are nested as such, the most specific route will be chosen.

**Testing**

Ideally I'd have extended tests to cover this case, but there aren't any and it feels outside of the scope of this change to add them. [I've created an issue for this](https://github.com/mtbrault/nextjs-http-supertest/issues/6).