### PR TITLE
fix: matching longer-by-one route

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,10 @@ const getDynamicRoute = (routes, url) => {
     const routeParams = {};
     const routeSplit = route.split('/');
 
+    if (routeSplit.length !== urlSplit.length) {
+      continue;
+    }
+
     for (let index = 0; index < routeSplit.length; index++) {
       const routePath = routeSplit[index];
       const urlPath = urlSplit[index];


### PR DESCRIPTION
Given the following routes:
```
/users/[id]
/users
```

When making a request to `/users` we would expect the `/users` route to be resolved.

However the `/users/[id]` route is resolved. It tests this route first, and `index === routeSplit.length - 1` evaluates to true.